### PR TITLE
npm install 시 의존성 해결, 다중 디렉토리 변환 지원 추가, 컨트리뷰터 리스트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ File rename for NFD Unicode characters to NFC
 require('optimist')
 ```
 Options:
-  -d, --directory  [required]  [default: "."]
+  -d, --directory  [required]  [default: "."] [multiple directories support]
   -r, --recursive
 ```
 
@@ -48,4 +48,10 @@ node nfd2nfc.js -d "%USERPROFILE%\\Downloads\\node-nfd2nfc\\test\\"
 
 ```
 node nfd2nfc.js -d "%USERPROFILE%\\Downloads\\node-nfd2nfc\\test\\" -r
+```
+
+## 여러 폴더 변환 실행 (Recursive)
+
+```
+node nfd2nfc.js -d "%USERPROFILE%\\Downloads\\node-nfd2nfc\\test\\" -d "%USERPROFILE%\\Downloads\\node-nfd2nfc\\test2\\" -r
 ```

--- a/nfd2nfc.js
+++ b/nfd2nfc.js
@@ -19,7 +19,7 @@ var target_dir = argv.directory;
 var walk = function(argDir) {
   if (!fs.existsSync(argDir)) {
     console.log("Directory " + argDir + " is not exist!");
-    process.exit(1);
+    return -1;
   }
 
   var dirList = fs.readdirSync(argDir); 
@@ -50,6 +50,22 @@ var walk = function(argDir) {
 
     file = argDir + '/' + file;
   });
+
+  return 0;
 }
 
-walk(target_dir);
+// main routine
+var ret = 0;
+if (typeof target_dir != "string"){
+  // multiple options
+  target_dir.forEach(function(item){
+    ret += walk(item);
+  });
+}else{
+  // single options
+  ret += walk(target_dir);
+}
+// return error count
+// 0 is fine
+// negetive number means error count, for example, -2 means two error
+process.exit(ret);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,13 @@
     "Rename"
   ],
   "author": "kiros33",
+  "contributors": [
+    {
+      "name": "ninetiger",
+      "email" : "admin@ninetiger.com",
+      "url" : "http://blog.ninetiger.com/"
+    }
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/kiros33/node-nfd2nfc/issues"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/kiros33/node-nfd2nfc/issues"
   },
-  "homepage": "https://github.com/kiros33/node-nfd2nfc#readme"
+  "homepage": "https://github.com/kiros33/node-nfd2nfc#readme",
+  "dependencies": {
+    "optimist": "^0.6.1"
+  }
 }


### PR DESCRIPTION
개인적으로 사용하기 위해서, 다중 디렉토리 변환 지원을 추가하였습니다.
관련된 사항은 readme에도 반영이 되어 있습니다.
사용하기 위해서는 이 깃을 클론받고, npm install 한번 쳐주고, 쓰면 됩니다.

나중에 다듬으셔도 됩니다. 저만 쓰기 아까워서 풀 리퀘스트 날립니다.
문의사항이 있으시면, 문의바랍니다.
